### PR TITLE
Fix exceptions on psutil.*missing*() methods

### DIFF
--- a/pysmime/util.py
+++ b/pysmime/util.py
@@ -130,9 +130,11 @@ def seed_prng():
                'net_connections', 'pids', 'disk_partitions']
     try:
         # Python 3
-        Rand.rand_seed(bytes(''.join([str(getattr(psutil, a)())
+        Rand.rand_seed(bytes(''.join([str(getattr(psutil, a, str)())
                        for a in sources]), 'utf-8'))
     except TypeError:
         # Python 2
-        Rand.rand_seed(str([getattr(psutil, a)()
+        Rand.rand_seed(str([getattr(psutil, a, str)()
                        for a in sources]))
+
+    return True

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+#
+# tests/test_util.py
+# Filip Valder <fvalder@redhat.com>
+# http://www.redhat.com
+# License: http://www.gnu.org/licenses/gpl.txt
+
+"""
+Test `util` functions
+"""
+
+from pysmime import util
+
+
+def test_seed_prng():
+    assert util.seed_prng() is True


### PR DESCRIPTION
The reason for this is that some versions of psutil may not support some methods, like:
`AttributeError: 'ModuleWrapper' object has no attribute 'sensors_temperatures'` im my case.

```
  flake8: commands succeeded
  py27: commands succeeded
  py34: commands succeeded
  py35: commands succeeded
  py36: commands succeeded
  congratulations :)
```